### PR TITLE
Fix a couple of compile errors and logical problems.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
 	        "target_name": "node-rpi-rgb-led-matrix",
 	        "sources": [ "src/base.cc", "src/ledmatrix.cc", "src/image.cc" ],
 	        "dependencies": [ "./binding.gyp:rpi-rgb-led-matrix" ],
-	        "include_dirs": [ "./external/matrix/include", "./include/", "<!(node -e \"require('nan')\")" ]
+	        "include_dirs": [ "./external/matrix/include", "./include/", "<!(nodejs -e \"require('nan')\")" ]
 	    },
 		{
 			"target_name": "rpi-rgb-led-matrix",

--- a/include/image.h
+++ b/include/image.h
@@ -16,9 +16,9 @@ class Pixel {
 		// Pixel() : red(0), green(0), blue(0) {}
 		Pixel();
 
-		const uint8_t R();
-		const uint8_t G();
-		const uint8_t B();
+		uint8_t R() const;
+		uint8_t G() const;
+		uint8_t B() const;
 
 		void SetR(uint8_t r);
 		void SetG(uint8_t g);

--- a/src/image.cc
+++ b/src/image.cc
@@ -14,9 +14,9 @@
 
 Pixel::Pixel() : red(0), green(0), blue(0) {}
 
-const uint8_t Pixel::R() { return red; }
-const uint8_t Pixel::G() { return green; }
-const uint8_t Pixel::B() { return blue; }
+uint8_t Pixel::R() const { return red; }
+uint8_t Pixel::G() const { return green; }
+uint8_t Pixel::B() const { return blue; }
 
 void Pixel::SetR(uint8_t r) { red = r; }
 void Pixel::SetG(uint8_t g) { green = g; }

--- a/src/ledmatrix.cc
+++ b/src/ledmatrix.cc
@@ -10,6 +10,7 @@
 #include <node.h>
 
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <led-matrix.h>
 #include <ledmatrix.h>
@@ -161,7 +162,7 @@ void LedMatrix::GetHeight(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 void LedMatrix::SetPixel(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 	LedMatrix* matrix = ObjectWrap::Unwrap<LedMatrix>(args.Holder());
 
-	if(!args.Length() == 5 || !args[0]->IsNumber() || !args[1]->IsNumber() || !args[2]->IsNumber()
+	if(args.Length() != 5 || !args[0]->IsNumber() || !args[1]->IsNumber() || !args[2]->IsNumber()
 	|| !args[3]->IsNumber() || !args[4]->IsNumber()) {
 		Nan::ThrowTypeError("Wrong parameters! Expects 5 numbers");
   	}
@@ -192,7 +193,7 @@ void LedMatrix::Clear(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 void LedMatrix::Fill(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 	LedMatrix* matrix = ObjectWrap::Unwrap<LedMatrix>(args.Holder());
 
-	if(!args.Length() == 3 || !args[0]->IsNumber() || !args[1]->IsNumber() || !args[2]->IsNumber()) {
+	if(args.Length() != 3 || !args[0]->IsNumber() || !args[1]->IsNumber() || !args[2]->IsNumber()) {
 		Nan::ThrowTypeError("Wrong parameters! Expects 3 numbers");
 	}
 
@@ -214,7 +215,7 @@ void LedMatrix::SetImageBuffer(const Nan::FunctionCallbackInfo<v8::Value>& args)
 	int width = args[1]->ToInteger()->Value();
 	int height = args[2]->ToInteger()->Value();
 
-	assert(bufl == width*height*3);
+	assert((int)bufl == width*height*3);
 
 	Image* img = new Image();
 	Pixel* pixels = (Pixel*) malloc(sizeof(Pixel)*width*height);


### PR DESCRIPTION
o ledmatrix.cc: include unistd.h to be able to use usleep().
o ledmatrix.cc: Fix logical error when validating passed parameters.
     (!expr == 5) first negates expression, then compares with 5. What
     was meant was (expr != 5)
o ledmatrix.cc: Fix comparison in assert() between signed int and
  unsigned size_t
o image.{h,cc}: getters for colors were returning 'const uint8_t', which
  does not make much sense as the return value is always returned by
  value (and is ignored by the compiler). While at it, make the
  _methods_ const, which is a useful trait.
o Fix installation script that referred to 'node' instead of 'nodejs'
o Add missing newlines at end of *.h and *.cc files (technically, a missing newline at the end of input is an invalid c file).

Fixes #9