### PR TITLE
Smallest possible changes to put inline with hzeller

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,10 +9,24 @@
 		{
 			"target_name": "rpi-rgb-led-matrix",
 			"type": "static_library",
-			"sources": ["external/matrix/lib/bdf-font.cc",
-				"external/matrix/lib/framebuffer.cc", "external/matrix/lib/gpio.cc",
-				"external/matrix/lib/graphics.cc", "external/matrix/lib/led-matrix.cc",
-				"external/matrix/lib/thread.cc"],
+			"sources": [
+
+			"./external/matrix/lib/transformer.cc",
+			"./external/matrix/lib/thread.cc",
+			"./external/matrix/lib/pixel-mapper.cc",
+			"./external/matrix/lib/options-initialize.cc",
+			"./external/matrix/lib/multiplex-mappers.cc",
+			"./external/matrix/lib/led-matrix-c.cc",
+			"./external/matrix/lib/led-matrix.cc",
+			"./external/matrix/lib/graphics.cc",
+			"./external/matrix/lib/gpio.cc",
+			"./external/matrix/lib/framebuffer.cc",
+			"./external/matrix/lib/content-streamer.cc",
+			"./external/matrix/lib/bdf-font.cc",
+			"./external/matrix/lib/hardware-mapping.c",
+
+			],
+
 			"libraries": ["-lrt", "-lm", "-lpthread"],
 			"include_dirs": [ "external/matrix/include" ],
 	        "direct_dependent_settings": {

--- a/include/ledmatrix.h
+++ b/include/ledmatrix.h
@@ -43,7 +43,7 @@ class LedMatrix : public node::ObjectWrap {
 					bool looph, bool loopv);
 
 	protected:
-		LedMatrix(int rows = 16, int chained_displays = 1, int parallel_displays = 1);
+		LedMatrix(int rows , int cols , int chained_displays , int parallel_displays, const char* mapping);
 
 		virtual ~LedMatrix();
 


### PR DESCRIPTION
Pulled submodules, updated binding.gyp, and the constructors in ledmatrix.cc to compile and run with the latest version of https://github.com/hzeller/rpi-rgb-led-matrix

Changed the parameters in the ctor to allow for rows and cols, and a hardware mapping parameter. 
Tested with chained 64x64 panels. 